### PR TITLE
feat: cycle cities via query param

### DIFF
--- a/src/DisplayComponent.tsx
+++ b/src/DisplayComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {
-  calculateBackgroundColorBasedOnTemprature,
+  calculateBackgroundColorBasedOntemperature,
   calculateWindDirectionBasedOnDegree,
 } from './UIHelperFunctions';
 import { weatherMachineContext } from './machines/WeatherMachine';
@@ -115,7 +115,7 @@ const DividerComponent = styled.div`
   }
 `;
 
-const StyledTempratureTitle = styled.h3`
+const StyledtemperatureTitle = styled.h3`
   font-size: 10rem;
   margin: 0;
   @media (min-width: 768px) {
@@ -163,8 +163,8 @@ const DisplayComponent = ({ context }: DisplayProps) => {
 
   return (
     <StyledContainer
-      backgroundColor={calculateBackgroundColorBasedOnTemprature(
-        currentCity.data.temprature
+      backgroundColor={calculateBackgroundColorBasedOntemperature(
+        currentCity.data.temperature
       )}
     >
       <BackgroundIconWrapper
@@ -181,9 +181,9 @@ const DisplayComponent = ({ context }: DisplayProps) => {
           alt={weatherIconsMap[icon]}
         />
         <DividerComponent />
-        <StyledTempratureTitle>
-          {Math.round(currentCity.data.temprature || 0)}°
-        </StyledTempratureTitle>
+        <StyledtemperatureTitle>
+          {Math.round(currentCity.data.temperature || 0)}°
+        </StyledtemperatureTitle>
         <StyledMinorWrapper>
           <StyledMinorTitle>
             <StyledMinorIconImage

--- a/src/RequiresLocation.tsx
+++ b/src/RequiresLocation.tsx
@@ -12,7 +12,7 @@ const ContainerStyle = styled.div({
   alignItems: 'center',
 });
 
-const StartComponent = () => (
+export const RequiresLocation = () => (
   <div
     style={{
       background: 'rgb(50, 150, 210)',
@@ -55,5 +55,3 @@ const StartComponent = () => (
     </ContainerStyle>
   </div>
 );
-
-export default StartComponent;

--- a/src/UIHelperFunctions.ts
+++ b/src/UIHelperFunctions.ts
@@ -2,14 +2,14 @@ type singleDirectionEnum = {
   [key: string]: [number, number];
 };
 
-export const calculateBackgroundColorBasedOnTemprature = (temp: number = 0) => {
+export const calculateBackgroundColorBasedOntemperature = (temp: number = 0) => {
   // Define color stop-points
   const tenPercentDeepBlue = [4, 6, 14]; // 10c
   const tenPercentLightBlue = [5, 15, 21]; // 20c
   const tenPercentYellow = [25, 20, 0]; // 30c
   const tenPercentRed = [19, 6, 4]; // 40c
 
-  // for a range of +-10c around temprature, create new color varation by building
+  // for a range of +-10c around temperature, create new color varation by building
   // it ten percent for each degree in the range
   const output = [0, 0, 0];
   new Array(10).fill(0).forEach((_tenPercentDegree, index) => {

--- a/src/machines/BackgroundMachine.ts
+++ b/src/machines/BackgroundMachine.ts
@@ -1,4 +1,4 @@
-import { Machine as machine, assign } from 'xstate';
+import { createMachine, assign } from 'xstate';
 import axios, { AxiosResponse } from 'axios';
 
 import { weatherMachineCity } from './WeatherMachine';
@@ -43,20 +43,20 @@ type BackgroundMachineContext = {
   videos: any[];
 };
 
-export const BackgroundMachine = machine<BackgroundMachineContext>(
+export const backgroundMachine = createMachine<BackgroundMachineContext>(
   {
     id: 'background',
-    initial: 'gettingYoutubeData',
+    initial: 'loading',
     context: {
       cities: [],
       videos: [],
     },
     states: {
-      gettingYoutubeData: {
+      loading: {
         invoke: {
           src: 'requestYoutubeData',
           onDone: {
-            target: 'filterYoutubeData',
+            target: 'loaded',
             actions: assign({
               videos: (context, event: any) => {
                 return event.data;
@@ -65,7 +65,7 @@ export const BackgroundMachine = machine<BackgroundMachineContext>(
           },
         },
       },
-      filterYoutubeData: {
+      loaded: {
         invoke: {
           src: 'processYoutubeData',
           onDone: 'processed',
@@ -129,5 +129,3 @@ export const BackgroundMachine = machine<BackgroundMachineContext>(
     },
   }
 );
-
-export default BackgroundMachine;

--- a/src/stories/DisplayComponent.stories.tsx
+++ b/src/stories/DisplayComponent.stories.tsx
@@ -13,62 +13,62 @@ export default {
 const multipleCities: weatherMachineContext = {
   cities: [
     {
-      coords: { lat: 0, lng: 0 },
+      coords: { latitude: 0, longitude: 0 },
       name: 'texas',
       data: {
         deg: 170,
         humidity: 76,
         icon: '02n',
         name: 'Texas',
-        temprature: 15,
+        temperature: 15,
         wind: 4.12,
       },
     },
     {
-      coords: { lat: 0, lng: 0 },
+      coords: { latitude: 0, longitude: 0 },
       name: 'cairo',
       data: {
         deg: 320,
         humidity: 37,
         icon: '50d',
         name: 'Cairo',
-        temprature: 30,
+        temperature: 30,
         wind: 2,
       },
     },
     {
-      coords: { lat: 0, lng: 0 },
+      coords: { latitude: 0, longitude: 0 },
       name: 'berlin',
       data: {
         deg: 310,
         humidity: 62,
         icon: '04n',
         name: 'Berlin',
-        temprature: 2,
+        temperature: 2,
         wind: 16,
       },
     },
     {
-      coords: { lat: 0, lng: 0 },
+      coords: { latitude: 0, longitude: 0 },
       name: 'tokyo',
       data: {
         deg: 200,
         humidity: 94,
         icon: '50n',
         name: 'Tokyo',
-        temprature: 22,
+        temperature: 22,
         wind: 7,
       },
     },
     {
-      coords: { lat: 0, lng: 0 },
+      coords: { latitude: 0, longitude: 0 },
       name: 'dubai',
       data: {
         deg: 280,
         humidity: 34,
         icon: '01d',
         name: 'Dubai',
-        temprature: 45,
+        temperature: 45,
         wind: 5,
       },
     },
@@ -79,14 +79,14 @@ const multipleCities: weatherMachineContext = {
 const singleCity: weatherMachineContext = {
   cities: [
     {
-      coords: { lat: 0, lng: 0 },
+      coords: { latitude: 0, longitude: 0 },
       name: 'tokyo',
       data: {
         deg: 200,
         humidity: 94,
         icon: '50n',
         name: 'Tokyo',
-        temprature: 7.35,
+        temperature: 7.35,
         wind: 4.12,
       },
     },


### PR DESCRIPTION
**refactor**
- change state names
- use `always` and `withContext` to keep react code flatter
- put conditionals in guards
- use better `state.matches` in UI to keep react code flatter
- change some variable/file names for readability

**feat**
- parse `?cities` query param, put it in machine context
- on 5s interval cycle through cities and display data, reset to first city after last city displayed

fixes #1